### PR TITLE
Implemented padding and addin for df_paste

### DIFF
--- a/R/df_paste.R
+++ b/R/df_paste.R
@@ -19,11 +19,15 @@ df_paste <- function() {
 
   cols <- as.list(clipboard_table)
 
-  list_of_cols <- lapply(seq_along(cols), function(x) paste(names(cols[x]), "=",  cols[x]))
+  charw <- max(nchar(names(cols))) + 3L
 
-  output <- paste0(paste0("data.frame(\n",
-                   paste0(sapply(list_of_cols[1:length(list_of_cols) - 1], function(x) x), ",\n", collapse = ""),
-                   paste0(paste0(list_of_cols[length(list_of_cols)]), "\n)", collapse = "")), collapse = "")
+  list_of_cols <- lapply(seq_along(cols), function(x) paste(pad_to(names(cols[x]), charw), "=",  cols[x]))
+
+  output <- paste0(
+    paste0("data.frame(\n",
+           paste0(sapply(list_of_cols[1:length(list_of_cols) - 1], function(x) x), ",\n", collapse = ""),
+           paste0(paste0(list_of_cols[length(list_of_cols)]), "\n)", collapse = "")
+    ), collapse = "")
 
   rstudioapi::insertText(output)
 

--- a/inst/rstudio/addins.dcf
+++ b/inst/rstudio/addins.dcf
@@ -12,3 +12,8 @@ Name: Paste as vector (vertical)
 Description: Pastes data from the clipboard to the editor as character vector, formatted vertically, one element per line.
 Binding: vector_paste_vertical
 Interactive: false
+
+Name: Paste as data.frame
+Description: Pastes a table from the clipboard to the editor as a data.frame definition
+Binding: df_paste
+Interactive: false


### PR DESCRIPTION
Much neater now:

````
data.frame(
          X = c("Shower or two.", "Shower or two.", "Shower or two.", "Shower or two.", "Shower or two. Possible storm.", "Shower or two.", "Shower or two.", "Shower or two.", "Shower or two.", "Shower or two.", "Shower or two."),
   Location = c("Brisbane", "Brisbane Airport", "Beaudesert", "Chermside", "Gatton", "Ipswich", "Logan Central", "Manly", "Mount Gravatt", "Oxley", "Redcliffe"),
        Min = c("25", "25", "23", "24", "23", "23", "24", "26", "24", "24", "25"),
        Max = c("31", "29", "33", "31", "35", "33", "31", "28", "31", "32", "30")
)
````

I've also registered this as an RStudio addin. I bind to <kbd>CTRL</kbd>-<kbd>SHIFT</kbd>-<kbd>D</kbd> following your pattern.