### PR TITLE
Retain factor levels (even if unseen)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # datapasta 3.0.1
 * Exported `_format` functions
 * Adds `dt_paste` function for pasting as `data.table` (@jonocarroll, #72, closes #70)
+* Factor levels are now preserved (even if unseen) when pasting (@jonocarroll, #75, closes #39)
 
 # datapasta 3.0.0 'Colander Helmet'
 

--- a/R/dfdt_paste.R
+++ b/R/dfdt_paste.R
@@ -94,6 +94,7 @@ dfdt_construct <- function(input_table, oc = console_context(), class = NULL) {
       return(NULL)
     }
     col_types <- lapply(input_table, base::class) # prevent clobbering by local class variable
+    factor_levels <- lapply(input_table, levels)
     #Store types as characters so the char lengths can be computed
     input_table <- as.data.frame(lapply(input_table, as.character), stringsAsFactors = FALSE)
     #Store types as characters so the char lengths can be computed
@@ -119,7 +120,8 @@ dfdt_construct <- function(input_table, oc = console_context(), class = NULL) {
       lapply(which(col_types == "factor"), function(x) paste(pad_to(names(cols[x]), charw), "=",
                                                              paste0("as.factor(c(",
                                                                     paste0( unlist(lapply(cols[[x]], render_type, col_types[[x]])), collapse=", "),
-                                                                    "))"
+                                                                    "), levels = c(",
+                                                                    paste0(unlist(lapply(factor_levels[[x]], render_type, col_types[[x]])), collapse = ", "),"))"
                                                              )
       )
       )

--- a/R/dfdt_paste.R
+++ b/R/dfdt_paste.R
@@ -118,7 +118,7 @@ dfdt_construct <- function(input_table, oc = console_context(), class = NULL) {
   if(any(col_types == "factor")){
     list_of_factor_cols <-
       lapply(which(col_types == "factor"), function(x) paste(pad_to(names(cols[x]), charw), "=",
-                                                             paste0("as.factor(c(",
+                                                             paste0("factor(c(",
                                                                     paste0( unlist(lapply(cols[[x]], render_type, col_types[[x]])), collapse=", "),
                                                                     "), levels = c(",
                                                                     paste0(unlist(lapply(factor_levels[[x]], render_type, col_types[[x]])), collapse = ", "),"))"


### PR DESCRIPTION
Closes #39.

Added as a branch of the `dt_paste` PR because I wasn't sure how it would interact (diff will reduce significantly once that PR is merged).

Extracts (all) factor levels and pastes them into the `factor` (not `as.factor`) call.

```r
head(iris) %>% df_paste()
data.frame(
   Sepal.Length = c(5.1, 4.9, 4.7, 4.6, 5, 5.4),
    Sepal.Width = c(3.5, 3, 3.2, 3.1, 3.6, 3.9),
   Petal.Length = c(1.4, 1.4, 1.3, 1.5, 1.4, 1.7),
    Petal.Width = c(0.2, 0.2, 0.2, 0.2, 0.2, 0.4),
        Species = factor(c("setosa", "setosa", "setosa", "setosa", "setosa",
                           "setosa"), levels = c("setosa", "versicolor",
                           "virginica"))
)
```

Please test thoroughly before merging.