### PR TITLE
Allow space as a separator

### DIFF
--- a/R/df_paste.R
+++ b/R/df_paste.R
@@ -66,14 +66,15 @@ df_construct <- function(input_table, oc = console_context()) {
     #Store types as characters so the char lengths can be computed
     cols <- as.list(input_table)
   }
+  names(cols) <- sapply(names(cols), function(x) ifelse(is.na(x), "\"NA\"", x)) # can't have NA as a column name
 
   contains_chars <- any(col_types == "character") #we'll need to add stringsAsFactors=FALSE if so.
 
   #Set the column name width
-  charw <- max(max(nchar(names(cols))) + 3L, 12L)
+  charw <- max(max(nchar(paste(names(cols)))) + 3L, 12L)
 
   #Generate lists of data formatted for output
-  list_of_cols <- lapply(which(col_types != "factor"), function(x) paste(pad_to(names(cols[x]), charw), "=",
+  list_of_cols <- lapply(which(col_types != "factor"), function(x) paste(pad_to(paste(names(cols[x])), charw), "=",
                                                                          paste0("c(",
                                                                                 paste0( unlist(lapply(cols[[x]], render_type, col_types[[x]])), collapse=", "),
                                                                                 ")"
@@ -83,7 +84,7 @@ df_construct <- function(input_table, oc = console_context()) {
   #Handle the factor columns specially.
   if(any(col_types == "factor")){
     list_of_factor_cols <-
-      lapply(which(col_types == "factor"), function(x) paste(pad_to(names(cols[x]), charw), "=",
+      lapply(which(col_types == "factor"), function(x) paste(pad_to(paste(names(cols[x])), charw), "=",
                                                              paste0("as.factor(c(",
                                                                     paste0( unlist(lapply(cols[[x]], render_type, col_types[[x]])), collapse=", "),
                                                                     "))"
@@ -91,7 +92,7 @@ df_construct <- function(input_table, oc = console_context()) {
       )
       )
     list_of_cols <- c(list_of_cols, list_of_factor_cols)
-    names(list_of_cols) <- names(cols)
+    names(list_of_cols) <- paste(names(cols))
   }
 
   #paste0 inserts its own "\n" for lists which will mess witch what we're trying to do with tortellini.

--- a/R/tribble_paste.R
+++ b/R/tribble_paste.R
@@ -268,8 +268,8 @@ render_type_pad_to <- function(char_vec, char_type, char_length){
 #'
 #' @return the separator selected to parse char_vec as a table
 #'
-guess_sep <- function(char_vec){
-  candidate_seps <- c(",","\t","\\|",";")
+guess_sep <- function(char_vec) {
+  candidate_seps <- c(",","\t","\\|",";"," ")
   table_sample <- char_vec[1:min(length(char_vec),10)]
 
   #handle seps at end of line. A sep at the end of line is effectively an NA in the last column.

--- a/R/tribble_paste.R
+++ b/R/tribble_paste.R
@@ -94,7 +94,7 @@ tribble_construct <- function(input_table, oc = console_context()){
   # Set the column width depending on the max length of data as string or the header, whichever is longer.
   col_widths <- mapply(max,
                        col_widths,
-                       nchar(names(input_table))+1) #+1 for "~"
+                       nchar(paste(names(input_table)))+1) #+1 for "~"
 
   # Header
   header <- paste0(ifelse(oc$indent_head, yes = strrep(" ", oc$indent_context), no = ""), "tibble::tribble(\n")
@@ -106,7 +106,7 @@ tribble_construct <- function(input_table, oc = console_context()){
                         paste0(
                           mapply(
                             pad_to,
-                            paste0("~",names(input_table)),
+                            paste0("~",paste(names(input_table))),
                             col_widths
                           ),
                           ","
@@ -115,6 +115,7 @@ tribble_construct <- function(input_table, oc = console_context()){
                       )
                     ), "\n"
                 )
+  names_row <- sub("~NA,", "~\"NA\",", names_row) # can't have NA as a column name
 
 
   # Write correct data types
@@ -272,6 +273,9 @@ guess_sep <- function(char_vec) {
   candidate_seps <- c(",","\t","\\|",";"," ")
   table_sample <- char_vec[1:min(length(char_vec),10)]
 
+  #reduce multiple spaces to single space
+  table_sample <- gsub("[ ]+", " ", table_sample)
+
   #handle seps at end of line. A sep at the end of line is effectively an NA in the last column.
   table_sample <- gsub(",$", ", ", table_sample)
 
@@ -309,6 +313,8 @@ read_clip_tbl_guess <- function (x = clipr::read_clip(), ...)
     return(NULL)
   if(length(x) < 2)  #You're just a header row, get outta here!
     return(NULL)
+  # reduce multiple spaces to single
+  x <- gsub("[ ]+", " ", x)
   .dots <- list(...)
   .dots$file <- textConnection(x)
   if (is.null(.dots$header))
@@ -323,7 +329,7 @@ read_clip_tbl_guess <- function (x = clipr::read_clip(), ...)
   if (is.null(.dots$na.strings))
     .dots$na.strings <- c("NA", "")
   if (is.null(.dots$strip.white))
-    .dots$strip.white <- TRUE
+    .dots$strip.white <- !.dots$sep == " "
     .dots$quote <-  ""
   x_table <- do.call(utils::read.table, args = .dots)
 

--- a/tests/testthat/brisbane_weather_empty_lines_spaces.txt
+++ b/tests/testthat/brisbane_weather_empty_lines_spaces.txt
@@ -1,0 +1,13 @@
+
+X Location Min Max
+Partly_cloudy. Brisbane 19 29
+Partly_cloudy. Brisbane_Airport 18 27
+Possible_shower. Beaudesert 15 30
+Partly_cloudy. Chermside 17 29
+Shower_or_two._Possible_storm. Gatton 15 32
+Possible_shower. Ipswich 15 30
+Partly_cloudy. Logan_Central 18 29
+Mostly_sunny. Manly 20 26
+Partly_cloudy. Mount_Gravatt 17 28
+Possible_shower. Oxley 17 30
+Partly_cloudy. Redcliffe 19 27


### PR DESCRIPTION
Closes #61.

Simple fix to `guess_sep` to allow space to be used as a separator. Tested with the example provided.

```r
to RealAge
513 59.608
513 84.18
0 85.23
119 74.764
116 65.356
data.frame(
          to = c(513L, 513L, 0L, 119L, 116L),
     RealAge = c(59.608, 84.18, 85.23, 74.764, 65.356)
)
tibble::tribble(
   ~to, ~RealAge,
  513L,   59.608,
  513L,    84.18,
    0L,    85.23,
  119L,   74.764,
  116L,   65.356
  )
```

Also modified a test file for use with this

```r
datapasta:::guess_sep(readr::read_lines(file = "tests/testthat/brisbane_weather_empty_lines_spaces.txt"))
#> [1] " "
```