### PR TITLE
Handle invalid names when source is a tibble

### DIFF
--- a/R/tribble_paste.R
+++ b/R/tribble_paste.R
@@ -64,7 +64,7 @@ tribble_construct <- function(input_table, oc = console_context()){
     }
     input_table_types <- lapply(input_table, class)
     #Store types as characters so the char lengths can be computed
-    input_table <- as.data.frame(lapply(input_table, as.character), stringsAsFactors = FALSE)
+    input_table <- as.data.frame(lapply(input_table, as.character), stringsAsFactors = FALSE, check.names = FALSE)
   }
   # Warn if there is any factors, they will be converted to strings.
   factor_cols <- which(input_table_types == "factor")

--- a/tests/testthat/test_dfpaste.R
+++ b/tests/testthat/test_dfpaste.R
@@ -122,6 +122,24 @@ test_that("Columns with non-valid names can be parsed as a data.frame, with name
   )
 })
 
+test_that("Input tibbles with columns with non-valid names can be parsed as a data.frame, with names surrounded by backticks and check.names FALSE", {
+  expect_equal(
+    {eval( parse(text = dfdt_construct(tibble::tribble(
+      ~`!!`, ~`2015`, ~`%`, ~`TRUE`,
+      1L,     "b",   3L,   "D"
+    ), class = "data.frame")) )},
+    {
+      data.frame(stringsAsFactors=FALSE,
+                 check.names=FALSE,
+                 `!!` = c(1L),
+                 `2015` = c("b"),
+                 `%` = c(3L),
+                 `TRUE` = c("D")
+      )
+    }
+  )
+})
+
 test_that("meaningful rownames are included when input_table is a data.frame", {
   expect_equal(
     eval(parse(text = dfdt_construct(mtcars[1:3, 1:3], class = "data.frame"))),

--- a/tests/testthat/test_dtpaste.R
+++ b/tests/testthat/test_dtpaste.R
@@ -102,4 +102,39 @@ test_that("data.table contruct recognises raw data with no column headings and a
   )
 })
 
+test_that("Columns with non-valid names can be parsed as a table, with names surrounded by backticks and check.names FALSE", {
+  skip_if_not(is_clipr_available, skip_msg)
+  skip_on_cran()
+  skip_if_not(is_RStudio_session)
+  expect_equal(
+    {clipr::write_clip(readr::read_lines(file = "./non_valid_colnames.txt"))
+      eval(parse(text = dfdt_construct(class = "data.table")))},
+    {
+      data.frame(stringsAsFactors=FALSE,
+                 check.names=FALSE,
+                 `!!` = c(1L),
+                 `2015` = c("b"),
+                 `%` = c(3L),
+                 `TRUE` = c("D")
+      )
+    }
+  )
+})
 
+test_that("Input tibbles with columns with non-valid names can be parsed as a data.frame, with names surrounded by backticks and check.names FALSE", {
+  expect_equal(
+    {eval( parse(text = dfdt_construct(tibble::tribble(
+      ~`!!`, ~`2015`, ~`%`, ~`TRUE`,
+      1L,     "b",   3L,   "D"
+    ), class = "data.table")) )},
+    {
+      data.table::data.table(
+                 check.names=FALSE,
+                 `!!` = c(1L),
+                 `2015` = c("b"),
+                 `%` = c(3L),
+                 `TRUE` = c("D")
+      )
+    }
+  )
+})

--- a/tests/testthat/test_tribble.R
+++ b/tests/testthat/test_tribble.R
@@ -363,6 +363,21 @@ test_that("Columns with non-valid names can be parsed, with names surrounded by 
   )
 })
 
+test_that("Input tibbles with columns with non-valid names can be parsed, with names surrounded by backticks", {
+  expect_equal(
+    {eval( parse(text = tribble_construct(tibble::tribble(
+      ~`!!`, ~`2015`, ~`%`, ~`TRUE`,
+      1L,     "b",   3L,   "D"
+    ))) )},
+    {
+      tibble::tribble(
+        ~`!!`, ~`2015`, ~`%`, ~`TRUE`,
+        1L,     "b",   3L,   "D"
+      )
+    }
+  )
+})
+
 test_that("Columns that are completely blank (NA) are dropped", {
   skip_if_not(is_clipr_available, skip_msg)
   skip_on_cran()
@@ -390,7 +405,7 @@ test_that("blank final row has separator guessed as tab", {
 test_that("zero length tibbles work", {
 
   expect_equal(
-    eval(parse(text = 
+    eval(parse(text =
                  datapasta::tribble_construct(
                               tibble::tibble(a = character(), b = integer()))
                )


### PR DESCRIPTION
closes #108 

i know i said i couldn't fix this as fast as last time, but once i saw the fix was `check.names = FALSE` i knew i had to 😂 

added some tests too