### PR TITLE
Enable Positron use

### DIFF
--- a/R/tribble_paste.R
+++ b/R/tribble_paste.R
@@ -454,7 +454,7 @@ rstudio_context <- function(){
   output_context$indent_head <- FALSE #head already at cursor
   output_context$output_mode <- "rstudioapi"
   output_context$nspc <- 4
-  if rstudioapi::hasFun("readRStudioPreference") {
+  if (rstudioapi::hasFun("readRStudioPreference")) {
     rstudioapi::readRStudioPreference("num_spaces_for_tab", 4)
   }
   context <- rstudioapi::getActiveDocumentContext()

--- a/R/tribble_paste.R
+++ b/R/tribble_paste.R
@@ -453,8 +453,10 @@ rstudio_context <- function(){
   output_context <- list()
   output_context$indent_head <- FALSE #head already at cursor
   output_context$output_mode <- "rstudioapi"
-  output_context$nspc <- 
+  output_context$nspc <- 4
+  if rstudioapi::hasFun("readRStudioPreference") {
     rstudioapi::readRStudioPreference("num_spaces_for_tab", 4)
+  }
   context <- rstudioapi::getActiveDocumentContext()
   context_row <- context$selection[[1]]$range$start["row"]
   if(all(context$selection[[1]]$range$start == context$selection[[1]]$range$end)){

--- a/README.md
+++ b/README.md
@@ -83,6 +83,25 @@ There are two R functions available that accept R objects and output formatted t
 * `dpasta` accepts tibbles, data.frames, and vectors. Data is output in a format that matches in input class. Formatted text is pasted at the cursor.
 
 * `dmdclip` accepts the same inputs as `dpasta` but inserts the formatted text onto the clipboard, preceded by 4 spaces so that is can be as pasted as a preformatted block to Github, Stackoverflow etc.
+
+## Use with Positron
+
+`datapasta` works in Positron, but addins are not supported. You can use the functions directly from the console, or assign them keyboard shortcuts.
+For example, to assign `datapasta::tribble_paste()` the shortcut <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>t</kbd>, run the command **Preferences: Open Keyboard Shortcuts (JSON)** and add the following JSON to the array of shortcuts: 
+
+```json
+{
+    "key": "Ctrl+Shift+t",
+    "command": "workbench.action.executeCode.console",
+    "when": "editorTextFocus",
+    "args": {
+        "langId": "r",
+        "code": "datapasta::tribble_paste()",
+        "focus": true
+    }
+}
+```
+
     
 ## Use with other editors
 

--- a/tests/testthat/test_rstudio.R
+++ b/tests/testthat/test_rstudio.R
@@ -7,6 +7,7 @@ test_that("readPreference() returns an integer", {
     skip_on_travis()
     skip_if_not(is_interactive)
     skip_if_not(rstudioapi::isAvailable())
+    skip_if_not(rstudioapi::hasFun("readRStudioPreference"))
     expect_equal(rstudioapi::readPreference('num_spaces_for_tab', 4), 4)
 
 })


### PR DESCRIPTION
Check for `rstudio::readRStudioPreference()` before attempting to run it.

Allows `tribble_paste()` to work in Positron. Positron users will get 4 spaces for a tab with no consultation of their preferences.


